### PR TITLE
Fix for build warning

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -116,6 +116,7 @@
 			break;
         default:
             // NOP
+            break;
 	}
 
 	// Compute the target CGRect in order to keep aspect-ratio

--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -114,6 +114,8 @@
 		case UIImageOrientationRightMirrored:
 			boundingSize = CGSizeMake(boundingSize.height, boundingSize.width);
 			break;
+        default:
+            // NOP
 	}
 
 	// Compute the target CGRect in order to keep aspect-ratio


### PR DESCRIPTION
The switch statement in resizedImageToFitInSize:scaleIfSmaller: is missing the default: section.
