### PR TITLE
Fix for #8

### DIFF
--- a/Example/Classes/ImageResizeViewController.m
+++ b/Example/Classes/ImageResizeViewController.m
@@ -54,15 +54,15 @@
 	NSLog(@"Updating interface");
 	if (!self.srcImage) return;
 	
-	NSLog(@"Original image (%@): %@",self.srcImage,NSStringFromCGSize(self.srcImage.size));
+	NSLog(@"Original image (%@), width: %.0f, height: %.0f, scale: %0.2f",self.srcImage,self.srcImage.size.width, self.srcImage.size.height, self.srcImage.scale);
 	self.originalImageView.image = self.srcImage;
 	
 	UIImage* scaledImgH = [self.srcImage resizedImageToFitInSize:self.scaledImageViewH.bounds.size scaleIfSmaller:NO];
-	NSLog(@"Scaled image H (%@): %@",scaledImgH,NSStringFromCGSize(scaledImgH.size));
+	NSLog(@"Scaled image horizontal (%@), width: %.0f, height: %.0f, scale: %0.2f",scaledImgH,scaledImgH.size.width, scaledImgH.size.height, scaledImgH.scale);
 	self.scaledImageViewH.image = scaledImgH;
 
 	UIImage* scaledImgV = [self.srcImage resizedImageToFitInSize:self.scaledImageViewV.bounds.size scaleIfSmaller:NO];
-	NSLog(@"Scaled image V (%@): %@",scaledImgV,NSStringFromCGSize(scaledImgV.size));
+	NSLog(@"Scaled image horizontal (%@), width: %.0f, height: %.0f, scale: %0.2f",scaledImgV,scaledImgV.size.width, scaledImgV.size.height, scaledImgV.scale);
 	self.scaledImageViewV.image = scaledImgV;
 }
 

--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -76,7 +76,7 @@
 	
 	/////////////////////////////////////////////////////////////////////////////
 	// The actual resize: draw the image on a new context, applying a transform matrix
-	UIGraphicsBeginImageContextWithOptions(dstSize, NO, 0.0);
+	UIGraphicsBeginImageContextWithOptions(dstSize, NO, self.scale);
 	
 	CGContextRef context = UIGraphicsGetCurrentContext();
 	

--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -15,6 +15,11 @@
 	// the below values are regardless of orientation : for UIImages from Camera, width>height (landscape)
 	CGSize  srcSize = CGSizeMake(CGImageGetWidth(imgRef), CGImageGetHeight(imgRef)); // not equivalent to self.size (which is dependant on the imageOrientation)!
 	
+    /* Don't resize if we already meet the required destination size. */
+    if (CGSizeEqualToSize(srcSize, dstSize)) {
+        return self;
+    }
+    
 	CGFloat scaleRatio = dstSize.width / srcSize.width;
 	UIImageOrientation orient = self.imageOrientation;
 	CGAffineTransform transform = CGAffineTransformIdentity;
@@ -104,7 +109,7 @@
 	// get the image size (independant of imageOrientation)
 	CGImageRef imgRef = self.CGImage;
 	CGSize srcSize = CGSizeMake(CGImageGetWidth(imgRef), CGImageGetHeight(imgRef)); // not equivalent to self.size (which depends on the imageOrientation)!
-	
+
 	// adjust boundingSize to make it independant on imageOrientation too for farther computations
 	UIImageOrientation orient = self.imageOrientation;  
 	switch (orient) {


### PR DESCRIPTION
I think this will fix the issue with scaling reported in #8. The UIGraphicsImageContext for resizing was being created with the device's scale rather than the source image's scale.
