### PR TITLE
return nil if ui cgcontext comes out NULL

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -79,6 +79,10 @@
 	UIGraphicsBeginImageContextWithOptions(dstSize, NO, self.scale);
 	
 	CGContextRef context = UIGraphicsGetCurrentContext();
+    
+       if (!context) {
+           return nil;
+       }
 	
 	if (orient == UIImageOrientationRight || orient == UIImageOrientationLeft) {
 		CGContextScaleCTM(context, -scaleRatio, scaleRatio);


### PR DESCRIPTION
Starting in Xcode5 usage of a NULL graphics context started kicking up the following warning:

```
CGContextDrawImage: invalid context 0x0. This is a serious error.
This application, or a library it uses, is using an invalid context 
and is thereby contributing to an overall degradation of system
stability and reliability. This notice is a courtesy: please fix this
problem. It will become a fatal error in an upcoming update.
```

If `resizedImageToSize:` is passed `CGRectZero` then you end up with a NULL graphics context. This fix causes an early bailout to prevent use of a NULL graphics context.
