### PR TITLE
Use 0.0 instead of self.size as the scale, defaulting to device scale.

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -76,7 +76,7 @@
 	
 	/////////////////////////////////////////////////////////////////////////////
 	// The actual resize: draw the image on a new context, applying a transform matrix
-	UIGraphicsBeginImageContextWithOptions(dstSize, NO, self.scale);
+	UIGraphicsBeginImageContextWithOptions(dstSize, NO, 0.0);
 	
 	CGContextRef context = UIGraphicsGetCurrentContext();
     


### PR DESCRIPTION
See https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIKitFunctionReference/#//apple_ref/c/func/UIGraphicsBeginImageContextWithOptions for details
